### PR TITLE
don't dereference int as uintptr_t

### DIFF
--- a/src/client/intercept/shared/client_types.cpp
+++ b/src/client/intercept/shared/client_types.cpp
@@ -51,17 +51,11 @@ namespace intercept {
 
         bool internal_object::is_null()
         {
-            uintptr_t data = (uintptr_t)(rv_data.data);
-            uintptr_t data_1 = data + 12;
-            uintptr_t data_2 = *(uintptr_t *)data_1;
-            if (data_2) {
-                uintptr_t data_3 = data_2 + 4;
-                uintptr_t val = *(uintptr_t *)data_3;
-                return !val;
-            }
-            else {
-                return true;
-            }
+            uintptr_t data = (uintptr_t)rv_data.data;
+            data = *(unsigned int *)(data+12);
+            if (data)
+                return !*(unsigned int *)(data+4);
+            return true;
         }
 
 


### PR DESCRIPTION
Aside from the commit itself, there should be IMHO some
initialization check for the library like

assert(sizeof(int) == 4);
assert(sizeof(int*) >= sizeof(int));

or something like that, to prevent surprises.


------------
The original code works only on 32bit "by chance" as it relies on

  sizeof(int) == sizeof(uintptr_t) == sizeof(int*)

whereas uintptr_t is defined in ISO9899:1999 as

  "an unsigned integer type with the property that any valid pointer
   to void can be converted to this type, then converted back to
   pointer to void, and the result will compare equal to the original
   pointer"

which implies

  sizeof(uintptr_t) == sizeof(void*)
  and sizeof(void*) == sizeof(int*)  (on any sane platform)

Assuming the dereferenced values we're interested in (and which
we're adding to) are 32bit ints, do an explicit cast to uint*.
