### PR TITLE
Add near_objects wrapper and alt syntax for nearest_building

### DIFF
--- a/src/client/intercept/client/sqf/uncategorized.cpp
+++ b/src/client/intercept/client/sqf/uncategorized.cpp
@@ -3670,6 +3670,10 @@ namespace intercept {
 			return __helpers::__object_unary_object(client::__sqf::unary__nearestbuilding__object__ret__object, value_);
 		}
 
+        object nearest_building(const vector3 &value_) {
+            return object(host::functions.invoke_raw_unary(client::__sqf::unary__nearestbuilding__array__ret__object, value_));
+        }
+
 		float need_reload(const object &value_) {
 			return __helpers::__number_unary_object(client::__sqf::unary__needreload__object__ret__scalar, value_);
 		}
@@ -5927,8 +5931,7 @@ namespace intercept {
             return __helpers::__retrieve_nular_number(client::__sqf::nular__timemultiplier__ret__scalar);
         }
 
-        float date_to_number(game_date date_)
-        {
+        float date_to_number(game_date date_) {
             //game_value date_array({
             //	(date_.year),
             //	(date_.month),
@@ -5938,6 +5941,56 @@ namespace intercept {
             //})
 
             throw 713; // TODO reimplement day_to_number
+        }
+
+        std::vector<object> near_objects(const vector3 &pos_, const float &radius_) {
+            game_value ret = host::functions.invoke_raw_binary(__sqf::binary__nearobjects__object_array__scalar_array__ret__array, pos_, radius_);
+
+            std::vector<object> ret_objects;
+            for (uint32_t i = 0; i < ret.length(); ++i)
+                ret_objects.push_back(object(ret[i].rv_data));
+
+            return ret_objects;
+        }
+
+        std::vector<object> near_objects(const object &object_, const float &radius_) {
+            game_value ret = host::functions.invoke_raw_binary(__sqf::binary__nearobjects__object_array__scalar_array__ret__array, object_, radius_);
+
+            std::vector<object> ret_objects;
+            for (uint32_t i = 0; i < ret.length(); ++i)
+                ret_objects.push_back(object(ret[i].rv_data));
+
+            return ret_objects;
+        }
+
+        std::vector<object> near_objects(const vector3 &pos_, const std::string &type_, const float &radius_) {
+            game_value args(std::vector<game_value>{
+                type_,
+                radius_
+            });
+
+            game_value ret = host::functions.invoke_raw_binary(__sqf::binary__nearobjects__object_array__scalar_array__ret__array, pos_, args);
+
+            std::vector<object> ret_objects;
+            for (uint32_t i = 0; i < ret.length(); ++i)
+                ret_objects.push_back(object(ret[i].rv_data));
+
+            return ret_objects;
+        }
+
+        std::vector<object> near_objects(const object &object_, const std::string &type_, const float &radius_) {
+            game_value args(std::vector<game_value>{
+                type_,
+                radius_
+            });
+
+            game_value ret = host::functions.invoke_raw_binary(__sqf::binary__nearobjects__object_array__scalar_array__ret__array, object_, args);
+
+            std::vector<object> ret_objects;
+            for (uint32_t i = 0; i < ret.length(); ++i)
+                ret_objects.push_back(object(ret[i].rv_data));
+
+            return ret_objects;
         }
 
 

--- a/src/client/intercept/client/sqf/uncategorized.hpp
+++ b/src/client/intercept/client/sqf/uncategorized.hpp
@@ -94,7 +94,7 @@ namespace intercept {
         object create_vehicle_local(const std::string &type_, const vector3 &pos_atl_);
 
         void draw_rectangle(const control &ctrl_, const vector2 center_pos_, float a_, float b_, float angle_, const rv_color &color_, const std::string &fill_texture_);
-        
+
         //@TODO: draw_icon could stand to have a few enums probably for arguments like shadow and align.
         void draw_icon(const control &ctrl_, const std::string &texture_, const rv_color &color_, const vector2 &pos_, float width_, float height_, float angle_, const std::string &text_, uint32_t shadow_, float text_size_, const std::string &font_, const std::string &align_);
         void draw_icon(const control &ctrl_, const std::string &texture_, const rv_color &color_, const object &pos_, float width_, float height_, float angle_, const std::string &text_, uint32_t shadow_, float text_size_, const std::string &font_, const std::string &align_);
@@ -1566,6 +1566,7 @@ namespace intercept {
 		std::string name(const object &value_);
 		std::string name_sound(const object &value_);
 		object nearest_building(const object &value_);
+        object nearest_building(const vector3 &value_);
 		float need_reload(const object &value_);
 		std::string net_id(const object &value_);
 		std::string net_id(const group &value_);
@@ -2019,5 +2020,10 @@ namespace intercept {
 		std::string task_state(task value_);
 		void terminate(script value_);
 		std::string type(task value_);
+
+        std::vector<object> near_objects(const vector3 &pos_, const float &radius_);
+        std::vector<object> near_objects(const object &object_, const float &radius_);
+        std::vector<object> near_objects(const vector3 &pos_, const std::string &type_, const float &radius_);
+        std::vector<object> near_objects(const object &object_, const std::string &type_, const float &radius_);
 	}
 }


### PR DESCRIPTION
My first intercept C++ PR, go easy. :grin: 
(I am totally not copying @BaerMitUmlaut)

Adds wrappers for:
- `nearestBuilding` alt syntax
- `nearObjects` main syntax (position or object)
- `nearObjects` alt syntax (position or object with array of string and number)