### PR TITLE
Move default values to .hpp

### DIFF
--- a/src/client/intercept/client/sqf/intersects.cpp
+++ b/src/client/intercept/client/sqf/intersects.cpp
@@ -59,7 +59,7 @@ namespace intercept {
             return __helpers::__line_intersects_surfaces(intersects_value);
         }
 
-        intersect_surfaces_list line_intersects_surfaces(const vector3 &begin_pos_asl_, const vector3 &end_pos_asl_, const object & ignore_obj1_, const object & ignore_obj2_, bool sort_mode_ = true, int max_results_ = 1, const std::string &lod1_ = "VIEW", const std::string &lod2_ = "FIRE") {
+        intersect_surfaces_list line_intersects_surfaces(const vector3 &begin_pos_asl_, const vector3 &end_pos_asl_, const object & ignore_obj1_, const object & ignore_obj2_, bool sort_mode_, int max_results_, const std::string &lod1_, const std::string &lod2_) {
             game_value array_input = game_value({
                 begin_pos_asl_,
                 end_pos_asl_,
@@ -75,7 +75,7 @@ namespace intercept {
             return __helpers::__line_intersects_surfaces(intersects_value);
         }
 
-        std::vector<object> line_intersects_with(const vector3 &begin_pos_, const vector3 &end_pos_, bool sort_by_distance_ = true) {
+        std::vector<object> line_intersects_with(const vector3 &begin_pos_, const vector3 &end_pos_, bool sort_by_distance_) {
             game_value array_input({
                 begin_pos_,
                 end_pos_,

--- a/src/client/intercept/client/sqf/intersects.hpp
+++ b/src/client/intercept/client/sqf/intersects.hpp
@@ -81,12 +81,12 @@ namespace intercept {
         *
         * @returns vector of intersections in format [[intersectPosASL, surfaceNormal, intersectObj, parentObject],...]
         */
-        intersect_surfaces_list line_intersects_surfaces(const vector3 &begin_pos_asl_, const vector3 &end_pos_asl_, const object& ignore_obj1_, const object& ignore_obj2_, bool sort_mode_, int max_results_, const std::string &lod1_, const std::string &lod2_);
+        intersect_surfaces_list line_intersects_surfaces(const vector3 &begin_pos_asl_, const vector3 &end_pos_asl_, const object& ignore_obj1_, const object& ignore_obj2_, bool sort_mode_ = true, int max_results_ = 1, const std::string &lod1_ = "VIEW", const std::string &lod2_ = "FIRE");
 
         /**
         * Returns objects intersecting with the virtual line from begPos to endPos
         */
-        std::vector<object> line_intersects_with(const vector3 &begin_pos_, const vector3 &end_pos_, bool sort_by_distance_);
+        std::vector<object> line_intersects_with(const vector3 &begin_pos_, const vector3 &end_pos_, bool sort_by_distance_ = true);
         std::vector<object> line_intersects_with(const vector3 &begin_pos_, const vector3 &end_pos_, bool sort_by_distance_, const object & ignore_obj_one_);
         std::vector<object> line_intersects_with(const vector3 &begin_pos_, const vector3 &end_pos_, bool sort_by_distance_, const object & ignore_obj_one_, const object & ignore_obj_two_);
 

--- a/src/client/intercept/client/sqf/uncategorized.cpp
+++ b/src/client/intercept/client/sqf/uncategorized.cpp
@@ -1324,7 +1324,7 @@ namespace intercept {
             return game_value(host::functions.invoke_raw_unary(client::__sqf::unary__configname__config__ret__string, config_entry_));
         }
 
-        std::vector<config> config_properties(const config &config_entry, const std::string& condition_ = "true", bool inherit = true) {
+        std::vector<config> config_properties(const config &config_entry, const std::string& condition_, bool inherit) {
             game_value array_entry({
                 config_entry,
                 condition_,
@@ -1430,8 +1430,7 @@ namespace intercept {
             return object(host::functions.invoke_raw_binary(__sqf::binary__createvehicle__string__array__ret__object, type_, pos_));
         }
 
-        object create_vehicle(const std::string &type_, const vector3 &pos_, const std::vector<marker> &markers_ = {}, float placement_ = 0.0f, const std::string &special_ = "NONE")
-        {
+        object create_vehicle(const std::string &type_, const vector3 &pos_, const std::vector<marker> &markers_, float placement_, const std::string &special_) {
             std::vector<game_value> markers;
             for (auto it : markers_) {
                 markers.push_back(it);

--- a/src/client/intercept/client/sqf/uncategorized.hpp
+++ b/src/client/intercept/client/sqf/uncategorized.hpp
@@ -340,7 +340,7 @@ namespace intercept {
         /* Config */
         std::vector<config> config_hierarchy(const config &config_entry_);
         std::string config_name(const config &config_entry_);
-        std::vector<config> config_properties(const config &config_entry,const std::string& condition_, bool inherit);
+        std::vector<config> config_properties(const config &config_entry,const std::string& condition_ = "true", bool inherit = true);
         std::string config_source_mod(const config &config_entry_);
         std::vector<std::string> config_source_mod_list(const config &config_entry_);
         float count(const config &config_entry_);
@@ -378,7 +378,7 @@ namespace intercept {
         std::vector<object> all_units_uav();
 
         object create_vehicle(const std::string &type_, const vector3 &pos_);
-        object create_vehicle(const std::string &type_, const vector3 &pos_, const std::vector<marker> &markers_, float placement_, const std::string &special_);
+        object create_vehicle(const std::string &type_, const vector3 &pos_, const std::vector<marker> &markers_ = {}, float placement_ = 0.0f, const std::string &special_ = "NONE");
         void delete_vehicle(const object &obj_);
 
         float server_time();


### PR DESCRIPTION
Fixes warnings reported by `sqf_wrapper_validation.py` on Travis:
```
WARNING: Found a default value ( = true) in implementation parameters (line_intersects_surfaces, intersects.cpp line 0)
WARNING: Found a default value ( = true) in implementation parameters (line_intersects_with, intersects.cpp line 0)
WARNING: Found a default value ( = "true") in implementation parameters (config_properties, uncategorized.cpp line 0)
WARNING: Found a default value ( = "NONE") in implementation parameters (create_vehicle, uncategorized.cpp line 0)
```