### PR TITLE
Fix Intercept breaking CBA event handlers

### DIFF
--- a/rv/addons/core/config.cpp
+++ b/rv/addons/core/config.cpp
@@ -551,8 +551,13 @@ class CfgPatches {
 #define EH_CLASS_DEF(x,y) y = QUOTE(with missionNamespace do { player sideChat QUOTE(QUOTE(x)) ; intercept_params_var set[ARR_2(intercept_params_index,+_this)]; 'intercept' callExtension ('rv_event:' + QUOTE(QUOTE(x)) + ',' + (str intercept_params_index)); intercept_params_index = intercept_params_index + 1;}; '';)
 
 class CfgVehicles {
-    class AllVehicles {
-        class EventHandlers {
+
+    class All {
+        class EventHandlers;
+    };
+
+    class AllVehicles: All {
+        class EventHandlers: EventHandlers {
             class Intercept {
                 EH_CLASS_DEF(anim_changed,animChanged);
                 EH_CLASS_DEF(anim_done,animDone);

--- a/rv/addons/core/config.cpp
+++ b/rv/addons/core/config.cpp
@@ -539,8 +539,7 @@ class CfgPatches {
             "a3_weapons_f_uniforms",
             "a3_weapons_f_vests",
             "a3data",
-            "map_vr",
-            "extended_eventhandlers"
+            "map_vr"
         };
         version = 0.1;
     };
@@ -548,7 +547,7 @@ class CfgPatches {
 
 #define QUOTE(var1) #var1
 #define ARR_2(ARG1,ARG2) ARG1, ARG2
-#define EH_CLASS_DEF(x,y) y = QUOTE(with missionNamespace do { player sideChat QUOTE(QUOTE(x)) ; intercept_params_var set[ARR_2(intercept_params_index,+_this)]; 'intercept' callExtension ('rv_event:' + QUOTE(QUOTE(x)) + ',' + (str intercept_params_index)); intercept_params_index = intercept_params_index + 1;}; '';)
+#define EH_CLASS_DEF(x,y) y = QUOTE(with missionNamespace do { intercept_params_var set[ARR_2(intercept_params_index,+_this)]; 'intercept' callExtension ('rv_event:' + QUOTE(QUOTE(x)) + ',' + (str intercept_params_index)); intercept_params_index = intercept_params_index + 1;}; '';)
 
 class CfgVehicles {
 

--- a/rv/addons/core/config.cpp
+++ b/rv/addons/core/config.cpp
@@ -547,7 +547,8 @@ class CfgPatches {
 
 #define QUOTE(var1) #var1
 #define ARR_2(ARG1,ARG2) ARG1, ARG2
-#define EH_CLASS_DEF(x,y) y = QUOTE(with missionNamespace do { intercept_params_var set[ARR_2(intercept_params_index,+_this)]; 'intercept' callExtension ('rv_event:' + QUOTE(QUOTE(x)) + ',' + (str intercept_params_index)); intercept_params_index = intercept_params_index + 1;}; '';)
+#define COMMA ,
+#define EH_CLASS_DEF(x,y) y = QUOTE(with missionNamespace do { intercept_params_var set[ARR_2(intercept_params_index,+_this)]; 'intercept' callExtension ('rv_event:' + QUOTE(QUOTE(x)) + QUOTE(QUOTE(COMMA)) + (str intercept_params_index)); intercept_params_index = intercept_params_index + 1;}; '';)
 
 class CfgVehicles {
 


### PR DESCRIPTION
Also remove unneeded CBA required addon and debug print.

According to @commy2 this solution is still very fragile:
> AllVehicles usually has no EventHandlers class, so this could change inheritance of addons loaded after intercept. And some sub classes of AllVehicles overwrite this EventHandlers class.
> It's basically the same problem [CBA XEH has](https://github.com/CBATeam/CBA_A3/blob/master/addons/xeh/CfgVehicles.hpp).
> And this problem is also the reason why the new EventHandler sub classes cannot replace XEH

An alternative to this is PRed in #57